### PR TITLE
Api endpoint yield sum now works

### DIFF
--- a/datavis-api/appsettings.json
+++ b/datavis-api/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=postgres-db;Database=crop_yields_owid;Username=postgres;Password=postgres"
+    "__DefaultConnection": "Host=postgres-db;Database=crop_yields_owid;Username=postgres;Password=postgres",
+    "DefaultConnection": "Host=localhost;Database=crop_yields_owid;Username=postgres;Password=postgres"
   }
 }

--- a/datavis-api/appsettings.json
+++ b/datavis-api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "__DefaultConnection": "Host=postgres-db;Database=crop_yields_owid;Username=postgres;Password=postgres",
-    "DefaultConnection": "Host=localhost;Database=crop_yields_owid;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=postgres-db;Database=crop_yields_owid;Username=postgres;Password=postgres",
+    "__DefaultConnection": "Host=localhost;Database=crop_yields_owid;Username=postgres;Password=postgres"
   }
 }

--- a/datavis-api/src/Controllers/CropController.cs
+++ b/datavis-api/src/Controllers/CropController.cs
@@ -70,19 +70,13 @@ public class CropController : ControllerBase
     }
 
     // Endpoint for crop yield pie chart data
-    [HttpGet("cropyields/yearrange/crop")]
-    [ProducesResponseType(200, Type = typeof(ICollection<CropYieldDto>))]
-    public IActionResult GetCropYieldsWithinYearRangeByCrop
-    (
-        [FromQuery] int yearStart,
-        [FromQuery] int yearEnd,
-        [FromQuery] int cropId
-    )
+    [HttpGet("cropyields/crop/yearrange")]
+    [ProducesResponseType(200, Type = typeof(ICollection<CountryYieldSum>))]
+    public IActionResult GetCountryYieldSumByYearRangeAndCrop(int yearStart, int yearEnd, int cropId)
     {
-        ICollection<CropYieldDto> cropYieldsDto = _cropService.GetCropYieldsDtoWithinYearRangeByCrop(yearStart, yearEnd, cropId);
-
+        ICollection<CountryYieldSum> countryYields = _cropService.GetCountryYieldSumByYearRangeAndCrop(yearStart, yearEnd, cropId);
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        return Ok(cropYieldsDto);
+        return Ok(countryYields);
     }
 }

--- a/datavis-api/src/DbContexts/Generated/CropDataContext.cs
+++ b/datavis-api/src/DbContexts/Generated/CropDataContext.cs
@@ -7,8 +7,7 @@ public partial class CropDataContext : DbContext
 {
     public CropDataContext(DbContextOptions<CropDataContext> options)
         : base(options)
-    {
-    }
+    { }
 
     public virtual DbSet<Country> Countries { get; set; }
 
@@ -19,6 +18,7 @@ public partial class CropDataContext : DbContext
     public virtual DbSet<Year> Years { get; set; }
 
     public virtual DbSet<YieldsView> YieldsViews { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/datavis-api/src/Interfaces/ICropRepository.cs
+++ b/datavis-api/src/Interfaces/ICropRepository.cs
@@ -16,4 +16,5 @@ public interface ICropRepository
     IOrderedQueryable<CropYield> GetCropYieldsByCrop(int cropId);
     IOrderedQueryable<CropYield> GetCropYieldsByCountriesAndCrop(int[] countryIds, int cropId);
     IOrderedQueryable<CropYield> GetCropYieldsWithinYearRangeByCrop(int yearStart, int yearEnd, int cropId);
+    IQueryable<CountryYieldSum> GetCountryYieldSumByYearRangeAndCrop(int yearStart, int yearEnd, int cropId);
 }

--- a/datavis-api/src/Models/CountryYieldSum.cs
+++ b/datavis-api/src/Models/CountryYieldSum.cs
@@ -1,0 +1,6 @@
+// Used for aggregate crop yield data (sum of yields per country)
+public class CountryYieldSum
+{
+    public string name { get; set; }
+    public decimal total_yield { get; set; }
+}

--- a/datavis-api/src/Repositories/CropRepository.cs
+++ b/datavis-api/src/Repositories/CropRepository.cs
@@ -2,7 +2,6 @@ using DatavisApi.Interfaces;
 using DatavisApi.Data;
 using DatavisApi.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 
 namespace DatavisApi.Repository;
 
@@ -91,8 +90,48 @@ public class CropRepository : ICropRepository
                 cy.Year.Value >= yearStart &&
                 cy.Year.Value <= yearEnd &&
                 cy.Crop.Id == cropId
-            ).OrderBy(cy => cy.Id);
+            ).OrderByDescending(cy => cy.Id);
 
         return cropYields;
+    }
+
+    public IQueryable<CountryYieldSum> GetCountryYieldSumByYearRangeAndCrop(int yearStart, int yearEnd, int cropId)
+    {
+        string sqlQuery =
+            $"""        
+            WITH top_countries AS (
+                SELECT country.name, SUM(cy.value) AS total_yield
+                FROM crop_yield cy
+                    JOIN year ON year.id = cy.year_id
+                    JOIN crop ON crop.id = cy.crop_id
+                    JOIN country ON country.id = cy.country_id
+                WHERE
+                    crop.id = {cropId} AND
+                    year.value BETWEEN {yearStart} AND {yearEnd}
+                GROUP BY country.name
+                ORDER BY total_yield DESC
+                LIMIT 14
+            ),
+            other_countries AS (
+                SELECT SUM(cy.value) AS total_yield
+                FROM crop_yield cy
+                    JOIN year ON year.id = cy.year_id
+                    JOIN crop ON crop.id = cy.crop_id
+                    JOIN country ON country.id = cy.country_id
+                WHERE
+                    crop.id = {cropId} AND
+                    year.value BETWEEN {yearStart} AND {yearEnd} AND
+                    country.name NOT IN (SELECT name FROM top_countries)
+            )
+            SELECT name, total_yield
+            FROM top_countries
+            UNION ALL
+            SELECT 'Other', total_yield
+            FROM other_countries;
+            """;
+
+        IQueryable<CountryYieldSum> sumYields = _dataContext.Database.SqlQueryRaw<CountryYieldSum>(sqlQuery);
+
+        return sumYields;
     }
 }

--- a/datavis-api/src/Services/CropService.cs
+++ b/datavis-api/src/Services/CropService.cs
@@ -67,5 +67,12 @@ namespace DatavisApi.Services
 
             return cropYieldDtos;
         }
+
+        public ICollection<CountryYieldSum> GetCountryYieldSumByYearRangeAndCrop(int yearStart, int yearEnd, int cropId)
+        {
+            IQueryable<CountryYieldSum> sumYields = _cropRepository.GetCountryYieldSumByYearRangeAndCrop(yearStart, yearEnd, cropId);
+
+            return sumYields.ToList();
+        }
     }
 }

--- a/datavis-frontend-csr/src/app/services/data-request.service.ts
+++ b/datavis-frontend-csr/src/app/services/data-request.service.ts
@@ -11,16 +11,16 @@ import { ICrop } from '../interfaces/icrop';
 
 export class DataRequestService {
 
-  readonly ROOT_URL = "http://localhost:5065/crop-api"
+  readonly ROOT_URL = "http://localhost:5065/crop-api/"
   
   constructor(private http: HttpClient) { }
 
   public GetCountries(): Observable<ICountry[]> {
-    return this.http.get<ICountry[]>(this.ROOT_URL + "/countries");
+    return this.http.get<ICountry[]>(this.ROOT_URL + "countries");
   }
 
   public GetCrops(): Observable<ICrop[]> {
-    return this.http.get<ICrop[]>(this.ROOT_URL + "/crops");
+    return this.http.get<ICrop[]>(this.ROOT_URL + "crops");
   }
 
   public GetCropYieldsByCountriesAndCrop(countryIds: number[], cropId: number): Observable<ICropYield[]> {
@@ -28,9 +28,8 @@ export class DataRequestService {
     return this.http.get<ICropYield[]>(requestUrl);
   }
 
-
   private GenerateCropYieldRequestByCountriesAndCrop(countryIds: number[], cropId: number): string {
-    var requestUrl: string = this.ROOT_URL + "/cropyields/countries/crop?"
+    var requestUrl: string = this.ROOT_URL + "cropyields/countries/crop?"
     
     for (let countryId of countryIds){
       requestUrl += "countryIds=" + countryId + "&";

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,18 +11,18 @@ services:
     # depends_on:
     #   - datavis-api
 
-  # datavis-api:
-  #   image: datavis-api
-  #   restart: always
-  #   build:
-  #     context: ./datavis-api
-  #   ports:
-  #     - 5065:8080
-  #   environment:
-  #     - ASPNETCORE_ENVIRONMENT=Development
-  #   depends_on:
-  #     postgres-db:
-  #       condition: service_healthy
+  datavis-api:
+    image: datavis-api
+    restart: always
+    build:
+      context: ./datavis-api
+    ports:
+      - 5065:8080
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    depends_on:
+      postgres-db:
+        condition: service_healthy
 
   postgres-db:
     image: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,21 +8,21 @@ services:
       context: ./datavis-frontend-csr
     ports:
     - 4200:80
-    depends_on:
-      - datavis-api
+    # depends_on:
+    #   - datavis-api
 
-  datavis-api:
-    image: datavis-api
-    restart: always
-    build:
-      context: ./datavis-api
-    ports:
-      - 5065:8080
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-    depends_on:
-      postgres-db:
-        condition: service_healthy
+  # datavis-api:
+  #   image: datavis-api
+  #   restart: always
+  #   build:
+  #     context: ./datavis-api
+  #   ports:
+  #     - 5065:8080
+  #   environment:
+  #     - ASPNETCORE_ENVIRONMENT=Development
+  #   depends_on:
+  #     postgres-db:
+  #       condition: service_healthy
 
   postgres-db:
     image: postgres


### PR DESCRIPTION
Took forever to find out why the dbcontext.Database.SqlQuery<CountryYieldSum> didn't work. Seemed to be because the properties of CountryYieldSum weren't the exact same as the table column names in the sql query.